### PR TITLE
使用拍摄时间作为文件的修改时间

### DIFF
--- a/downloader.go
+++ b/downloader.go
@@ -11,6 +11,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"time"
 )
 
 type Downloader struct {
@@ -151,6 +152,12 @@ func (d *Downloader) downPhoto(folderName string, f *File) error {
 	if _, err := os.Stat(filePath); os.IsNotExist(err) {
 		if err := d.bucket.GetObjectToFile(f.Url, filePath); err != nil {
 			return fmt.Errorf("下载照片失败 url: %s, filePath: %s, err: %s", f.Url, filePath, err)
+		}
+
+		shootTime := time.Unix(f.ShootTime/1000, 0)
+
+		if err := os.Chtimes(filePath, shootTime, shootTime); err != nil {
+			log.Printf("设置文件时间失败 filePath: %s, err: %s", filePath, err)
 		}
 	} else if err != nil {
 		return fmt.Errorf("检查文件是否存在失败 filePath: %s, err: %s", filePath, err)


### PR DESCRIPTION
将服务器返回的照片拍摄时间 `shootTime`（而非当前时间）作为下载后文件的修改时间，这在照片的元数据中缺少拍摄时间时特别有用。

> Note:
> 在 Windows 系统上可能需要提权运行才可正常设置时间